### PR TITLE
[Finishes #14] Automate adding command files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,25 @@
 const discord = require('discord.js');
 const client = new discord.Client();
 
+const fs = require('fs');
+
 const prefix = ';';
 const adminID = '230249439481167872';
 
 client.commands = new discord.Collection();
 
-// List all arugments inside ./commands
-const commandFiles = [
-  'args-info',
-  'avatar',
-  'beep',
-  'kick',
-  'ping',
-  'prune',
-  'rules',
-  'server',
-  'user-info',
-];
-
 // Read commandFiles
-for (const file of commandFiles) {
-  const command = require(`./commands/${file}`);
-  client.commands.set(command.name, command);
-}
+
+fs.readdir('./src/commands/', (err, commands) => {
+  if (err) throw err;
+  
+  commands.forEach(command => {
+    const commandFile = require(`./commands/${command}`),
+    commandName = command.replace('.ts', '');
+
+    client.commands.set(commandName, commandFile);
+  });
+});
 
 // Bot Mount Event Trigger
 client.on('ready', () => {


### PR DESCRIPTION
# Story Title

[Fix the problem with node's `fs`](https://github.com/kuru-project/discord-bot/issues/14)

# Changes made

- Removed array that list commands
- Added automation that adds the command files using `fs` 

# How does the solution address the problem

This PR will solve #14  by adding command files with node's `fs` instead of defining them in an array.
