### PR TITLE
Fix the typo on the Prune error message #18

### DIFF
--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -3,7 +3,7 @@ module.exports = {
   description: 'Prune Messages',
   execute(message, args, adminID) {
     if (message.author.id !== adminID) {
-      return message.reply('You\'re not an powerful enough!');
+      return message.reply('You\'re not powerful enough!');
     }
 
     const amount = parseInt(args[0]) + 1;

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -3,21 +3,21 @@ module.exports = {
   description: 'Prune Messages',
   execute(message, args, adminID) {
     if (message.author.id !== adminID) {
-      return message.reply('You\' not an powerfule enough!');
+      return message.reply('You\'re not an powerful enough!');
     }
 
     const amount = parseInt(args[0]) + 1;
 
     if (isNaN(amount)) {
-      return message.reply('that doesn\'t seem to be a valid number.');
+      return message.reply('That doesn\'t seem to be a valid number.');
     }
     else if (amount <= 1 || amount > 100) {
-      return message.reply('you need to input a number between 1 and 99.');
+      return message.reply('You need to input a number between 1 and 99.');
     }
 
     message.channel.bulkDelete(amount, true).catch(err => {
       console.error(err);
-      message.channel.send('there was an error trying to prune messages in this channel!');
+      message.channel.send('There was an error trying to prune messages in this channel!');
     });
   },
 };


### PR DESCRIPTION
# Story Title

[Fix the typo on the Prune error message](https://github.com/kuru-project/discord-bot/issues/18)

# Changes made

- Fix the typo
- Capitalize the sentences on Prune

# How does the solution address the problem

This PR will fix the Typo and the Prune command.

# Linked issues

Resolves #18
